### PR TITLE
Fix some pycodestyle warnings

### DIFF
--- a/pyjobs/pycodestyle.py
+++ b/pyjobs/pycodestyle.py
@@ -5,7 +5,7 @@ ROOT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
 ROS_SRC_DIR = os.path.realpath(os.path.join(ROOT_DIR, 'ros', 'src'))
 PYJOBS_DIR = os.path.realpath(os.path.join(ROOT_DIR, 'pyjobs'))
 
-N_MAX_ERRORS = 121
+N_MAX_ERRORS = 71
 
 
 def main():
@@ -13,7 +13,7 @@ def main():
     cmd = ['docker', 'run', '--rm=true',
            '--volume={}:{}'.format(ROOT_DIR, ROOT_DIR),
            'eurobots/carnd_capstone',
-           'pycodestyle', '--count', ROS_SRC_DIR, PYJOBS_DIR]
+           'pycodestyle', '--statistics', '--count', ROS_SRC_DIR, PYJOBS_DIR]
 
     try:
         subprocess.check_output(cmd, stderr=subprocess.STDOUT)

--- a/ros/src/camera_info_publisher/yaml_to_camera_info_publisher.py
+++ b/ros/src/camera_info_publisher/yaml_to_camera_info_publisher.py
@@ -20,6 +20,7 @@ import rospy
 import yaml
 from sensor_msgs.msg import CameraInfo
 
+
 def yaml_to_CameraInfo(calib_yaml):
     """
     Parse a yaml file containing camera calibration data (as produced by
@@ -49,6 +50,7 @@ def yaml_to_CameraInfo(calib_yaml):
     camera_info_msg.P = calib_data["projection_matrix"]["data"]
     camera_info_msg.distortion_model = calib_data["distortion_model"]
     return camera_info_msg
+
 
 if __name__ == "__main__":
 

--- a/ros/src/styx/bridge.py
+++ b/ros/src/styx/bridge.py
@@ -31,7 +31,7 @@ TYPE = {
     'steer_cmd': SteeringCmd,
     'brake_cmd': BrakeCmd,
     'throttle_cmd': ThrottleCmd,
-    'image':Image
+    'image': Image
 }
 
 
@@ -122,10 +122,10 @@ class Bridge(object):
     def broadcast_transform(self, name, position, orientation):
         br = tf.TransformBroadcaster()
         br.sendTransform(position,
-            orientation,
-            rospy.Time.now(),
-            name,
-            "world")
+                         orientation,
+                         rospy.Time.now(),
+                         name,
+                         "world")
 
     def publish_odometry(self, data):
         pose = self.create_pose(data['x'], data['y'], data['z'], data['yaw'])
@@ -135,10 +135,9 @@ class Bridge(object):
         self.broadcast_transform("base_link", position, orientation)
 
         self.publishers['current_pose'].publish(pose)
-        self.vel = data['velocity']* 0.44704
+        self.vel = data['velocity'] * 0.44704
         self.angular = self.calc_angular(data['yaw'] * math.pi/180.)
         self.publishers['current_velocity'].publish(self.create_twist(self.vel, self.angular))
-
 
     def publish_controls(self, data):
         steering, throttle, brake = data['steering_angle'], data['throttle'], data['brake']

--- a/ros/src/styx/conf.py
+++ b/ros/src/styx/conf.py
@@ -2,9 +2,9 @@ from attrdict import AttrDict
 
 conf = AttrDict({
     'subscribers': [
-        {'topic':'/vehicle/steering_cmd', 'type': 'steer_cmd', 'name': 'steering'},
-        {'topic':'/vehicle/throttle_cmd', 'type': 'throttle_cmd', 'name': 'throttle'},
-        {'topic':'/vehicle/brake_cmd', 'type': 'brake_cmd', 'name': 'brake'},
+        {'topic': '/vehicle/steering_cmd', 'type': 'steer_cmd', 'name': 'steering'},
+        {'topic': '/vehicle/throttle_cmd', 'type': 'throttle_cmd', 'name': 'throttle'},
+        {'topic': '/vehicle/brake_cmd', 'type': 'brake_cmd', 'name': 'brake'},
     ],
     'publishers': [
         {'topic': '/current_pose', 'type': 'pose', 'name': 'current_pose'},

--- a/ros/src/styx/server.py
+++ b/ros/src/styx/server.py
@@ -16,16 +16,20 @@ msgs = []
 
 dbw_enable = False
 
+
 @sio.on('connect')
 def connect(sid, environ):
     print("connect ", sid)
 
+
 def send(topic, data):
     s = 1
     msgs.append((topic, data))
-    #sio.emit(topic, data=json.dumps(data), skip_sid=True)
+    # sio.emit(topic, data=json.dumps(data), skip_sid=True)
+
 
 bridge.register_server(send)
+
 
 @sio.on('telemetry')
 def telemetry(sid, data):
@@ -38,28 +42,33 @@ def telemetry(sid, data):
         topic, data = msgs.pop(0)
         sio.emit(topic, data=data, skip_sid=True)
 
+
 @sio.on('control')
 def control(sid, data):
     bridge.publish_controls(data)
+
 
 @sio.on('obstacle')
 def obstacle(sid, data):
     bridge.publish_obstacles(data)
 
+
 @sio.on('lidar')
 def obstacle(sid, data):
     bridge.publish_lidar(data)
+
 
 @sio.on('trafficlights')
 def trafficlights(sid, data):
     bridge.publish_traffic(data)
 
+
 @sio.on('image')
 def image(sid, data):
     bridge.publish_camera(data)
 
-if __name__ == '__main__':
 
+if __name__ == '__main__':
     # wrap Flask application with engineio's middleware
     app = socketio.Middleware(sio, app)
 

--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -1,8 +1,9 @@
 from styx_msgs.msg import TrafficLight
 
+
 class TLClassifier(object):
     def __init__(self):
-        #TODO load classifier
+        # TODO load classifier
         pass
 
     def get_classification(self, image):
@@ -15,5 +16,5 @@ class TLClassifier(object):
             int: ID of traffic light color (specified in styx_msgs/TrafficLight)
 
         """
-        #TODO implement light color prediction
+        # TODO implement light color prediction
         return TrafficLight.UNKNOWN

--- a/ros/src/tl_detector/light_publisher.py
+++ b/ros/src/tl_detector/light_publisher.py
@@ -11,6 +11,7 @@ import numpy as np
 import rospkg
 import math
 
+
 class TLPublisher(object):
     def __init__(self):
         rospy.init_node('tl_publisher')

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -13,6 +13,7 @@ import yaml
 
 STATE_COUNT_THRESHOLD = 3
 
+
 class TLDetector(object):
     def __init__(self):
         rospy.init_node('tl_detector')
@@ -100,9 +101,8 @@ class TLDetector(object):
             int: index of the closest waypoint in self.waypoints
 
         """
-        #TODO implement
+        # TODO implement
         return 0
-
 
     def project_to_image_plane(self, point_in_world):
         """Project point from 3D world coordinates to 2D camera image location
@@ -125,15 +125,15 @@ class TLDetector(object):
         trans = None
         try:
             now = rospy.Time.now()
-            self.listener.waitForTransform("/base_link",
-                  "/world", now, rospy.Duration(1.0))
+            self.listener.waitForTransform("/base_link", "/world", now,
+                                           rospy.Duration(1.0))
             (trans, rot) = self.listener.lookupTransform("/base_link",
-                  "/world", now)
+                                                         "/world", now)
 
         except (tf.Exception, tf.LookupException, tf.ConnectivityException):
             rospy.logerr("Failed to find camera to map transform")
 
-        #TODO Use tranform and rotation to calculate 2D position of light in image
+        # TODO Use tranform and rotation to calculate 2D position of light in image
 
         x = 0
         y = 0
@@ -159,9 +159,9 @@ class TLDetector(object):
 
         x, y = self.project_to_image_plane(light.pose.pose.position)
 
-        #TODO use light location to zoom in on traffic light in image
+        # TODO use light location to zoom in on traffic light in image
 
-        #Get classification
+        # Get classification
         return self.light_classifier.get_classification(cv_image)
 
     def process_traffic_lights(self):
@@ -178,13 +178,14 @@ class TLDetector(object):
         if(self.pose):
             car_position = self.get_closest_waypoint(self.pose.pose)
 
-        #TODO find the closest visible traffic light (if one exists)
+        # TODO find the closest visible traffic light (if one exists)
 
         if light:
             state = self.get_light_state(light)
             return light_wp, state
         self.waypoints = None
         return -1, TrafficLight.UNKNOWN
+
 
 if __name__ == '__main__':
     try:

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -31,6 +31,7 @@ that we have created in the `__init__` function.
 
 '''
 
+
 class DBWNode(object):
     def __init__(self):
         rospy.init_node('dbw_node')
@@ -61,7 +62,7 @@ class DBWNode(object):
         self.loop()
 
     def loop(self):
-        rate = rospy.Rate(50) # 50Hz
+        rate = rospy.Rate(50)  # 50Hz
         while not rospy.is_shutdown():
             # TODO: Get predicted throttle, brake, and steering using `twist_controller`
             # You should only publish the control commands if dbw is enabled

--- a/ros/src/twist_controller/dbw_test.py
+++ b/ros/src/twist_controller/dbw_test.py
@@ -50,7 +50,7 @@ class DBWTestNode(object):
         self.loop()
 
     def loop(self):
-        rate = rospy.Rate(10) # 10Hz
+        rate = rospy.Rate(10)  # 10Hz
         while not rospy.is_shutdown():
             rate.sleep()
         fieldnames = ['actual', 'proposed']

--- a/ros/src/twist_controller/lowpass.py
+++ b/ros/src/twist_controller/lowpass.py
@@ -2,7 +2,7 @@
 class LowPassFilter(object):
     def __init__(self, tau, ts):
         self.a = 1. / (tau / ts + 1.)
-        self.b = tau / ts / (tau / ts + 1.);
+        self.b = tau / ts / (tau / ts + 1.)
 
         self.last_val = 0.
         self.ready = False

--- a/ros/src/twist_controller/pid.py
+++ b/ros/src/twist_controller/pid.py
@@ -20,10 +20,10 @@ class PID(object):
     def step(self, error, sample_time):
         self.last_int_val = self.int_val
 
-        integral = self.int_val + error * sample_time;
-        derivative = (error - self.last_error) / sample_time;
+        integral = self.int_val + error * sample_time
+        derivative = (error - self.last_error) / sample_time
 
-        y = self.kp * error + self.ki * self.int_val + self.kd * derivative;
+        y = self.kp * error + self.ki * self.int_val + self.kd * derivative
         val = max(self.min, min(y, self.max))
 
         if val > self.max:

--- a/ros/src/twist_controller/yaw_controller.py
+++ b/ros/src/twist_controller/yaw_controller.py
@@ -1,5 +1,6 @@
 from math import atan
 
+
 class YawController(object):
     def __init__(self, wheel_base, steer_ratio, min_speed, max_lat_accel, max_steer_angle):
         self.wheel_base = wheel_base
@@ -10,7 +11,6 @@ class YawController(object):
         self.min_angle = -max_steer_angle
         self.max_angle = max_steer_angle
 
-
     def get_angle(self, radius):
         angle = atan(self.wheel_base / radius) * self.steer_ratio
         return max(self.min_angle, min(self.max_angle, angle))
@@ -19,7 +19,7 @@ class YawController(object):
         angular_velocity = current_velocity * angular_velocity / linear_velocity if abs(linear_velocity) > 0. else 0.
 
         if abs(current_velocity) > 0.1:
-            max_yaw_rate = abs(self.max_lat_accel / current_velocity);
+            max_yaw_rate = abs(self.max_lat_accel / current_velocity)
             angular_velocity = max(-max_yaw_rate, min(max_yaw_rate, angular_velocity))
 
-        return self.get_angle(max(current_velocity, self.min_speed) / angular_velocity) if abs(angular_velocity) > 0. else 0.0;
+        return self.get_angle(max(current_velocity, self.min_speed) / angular_velocity) if abs(angular_velocity) > 0. else 0.0

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -21,7 +21,7 @@ as well as to verify your TL classifier.
 TODO (for Yousuf and Aaron): Stopline location for each traffic light.
 '''
 
-LOOKAHEAD_WPS = 200 # Number of waypoints we will publish. You can change this number
+LOOKAHEAD_WPS = 200  # Number of waypoints we will publish. You can change this number
 
 
 class WaypointUpdater(object):
@@ -32,7 +32,6 @@ class WaypointUpdater(object):
         rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
 
         # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint below
-
 
         self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
 
@@ -63,8 +62,10 @@ class WaypointUpdater(object):
         waypoints[waypoint].twist.twist.linear.x = velocity
 
     def distance(self, waypoints, wp1, wp2):
+        def dl(a, b):
+            return math.sqrt((a.x-b.x)**2 + (a.y-b.y)**2 + (a.z-b.z)**2)
+
         dist = 0
-        dl = lambda a, b: math.sqrt((a.x-b.x)**2 + (a.y-b.y)**2  + (a.z-b.z)**2)
         for i in range(wp1, wp2+1):
             dist += dl(waypoints[wp1].pose.pose.position, waypoints[i].pose.pose.position)
             wp1 = i


### PR DESCRIPTION
This patch fixes these warnings, reducing the count to 71:

-E128 continuation line under-indented for visual indent
-E221 multiple spaces before operator
-E225 missing whitespace around operator
-E231 missing whitespace after ':'
-E261 at least two spaces before inline comment
-E265 block comment should start with '# '
-E302 expected 2 blank lines, found 1
-E303 too many blank lines (2)
-E305 expected 2 blank lines after class or function definition, found 1
-E703 statement ends with a semicolon
-E731 do not assign a lambda expression, use a def