### PR TITLE
Reduce the waypoint_loader publish rate to 1 Hz

### DIFF
--- a/ros/src/waypoint_loader/waypoint_loader.py
+++ b/ros/src/waypoint_loader/waypoint_loader.py
@@ -73,7 +73,7 @@ class WaypointLoader(object):
         return waypoints
 
     def publish(self, waypoints):
-        rate = rospy.Rate(40)
+        rate = rospy.Rate(1)
         while not rospy.is_shutdown():
             lane = Lane()
             lane.header.frame_id = '/world'


### PR DESCRIPTION
It currently never publishes at 40 Hz, as specified in the code,
but around 15 Hz, since it just cannot keep up with it.

The code is publishing an array of ~11.000 waypoints
which are all the same all the time.

Therefore, it does not make sense to publish them so often,
since they never change. This commit sets the publish
rate to 1 Hz so that the CPU is not wasting cycles on this.