### PR TITLE
Allow run.sh to use a ROS bag instead of the simulator

### DIFF
--- a/ros/launch/site_bag.launch
+++ b/ros/launch/site_bag.launch
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<launch>
+    <!-- Rosbag player -->
+    <arg name="bag_file"/>
+    <node pkg="rosbag" type="play" name="player" args="--loop $(arg bag_file)"/>
+
+    <!-- Site launch file -->
+    <include file="$(find styx)../../launch/site.launch"/>
+</launch>

--- a/run.sh
+++ b/run.sh
@@ -8,25 +8,47 @@ ROS_DIR="$THIS_DIR/ros"
 echo "Building the code..."
 $THIS_DIR/build.sh
 
-# Launch simulator if it's not running yet
-if pgrep "system_integr" > /dev/null
+if [ "$#" -eq 1 ]
 then
-    echo "Great, the simulator is already running!"
-else
-    echo "Starting the simulator..."
-    $THIS_DIR/ros/src/styx/unity_simulator_launcher.sh
-fi
+    BAG_DIR="$(cd "$(dirname "$1")" && pwd -P && cd - > /dev/null)"
+    BAG_NAME="$(basename "$1")"
+    BAG_FULL_PATH="$BAG_DIR/$BAG_NAME"
 
-# Launch ROS nodes
-docker run --rm=true --tty=true --interactive=true               \
-           --user=$(id --user):$(id --group)                     \
-           --volume="/tmp":"/.ros"                               \
-           --volume="$THIS_DIR":"$THIS_DIR"                      \
-           --workdir="$ROS_DIR"                                  \
-           --network=host                                        \
-           --env DISPLAY                                         \
-           --volume /tmp/.X11-unix:/tmp/.X11-unix                \
-           eurobots/carnd_capstone /bin/bash -c                  \
-           "source /opt/ros/kinetic/setup.bash;
-            source devel/setup.bash;
-            roslaunch launch/styx.launch"
+    # Launch the ROS nodes
+    docker run --rm=true --tty=true --interactive=true               \
+               --user=$(id --user):$(id --group)                     \
+               --volume="/tmp":"/.ros"                               \
+               --volume="$THIS_DIR":"$THIS_DIR"                      \
+               --workdir="$THIS_DIR"                                 \
+               --network=host                                        \
+               --env DISPLAY                                         \
+               --volume /tmp/.X11-unix:/tmp/.X11-unix                \
+               eurobots/carnd_capstone /bin/bash -c                  \
+               "source /opt/ros/kinetic/setup.bash;
+                source ros/devel/setup.bash;
+                roslaunch ros/launch/site_bag.launch bag_file:=$BAG_FULL_PATH"
+
+else
+    # Launch simulator if it's not running yet
+    if pgrep "system_integr" > /dev/null
+    then
+        echo "Great, the simulator is already running!"
+    else
+        echo "Starting the simulator..."
+        $THIS_DIR/ros/src/styx/unity_simulator_launcher.sh
+    fi
+
+    # Launch ROS nodes
+    docker run --rm=true --tty=true --interactive=true               \
+               --user=$(id --user):$(id --group)                     \
+               --volume="/tmp":"/.ros"                               \
+               --volume="$THIS_DIR":"$THIS_DIR"                      \
+               --workdir="$THIS_DIR"                                 \
+               --network=host                                        \
+               --env DISPLAY                                         \
+               --volume /tmp/.X11-unix:/tmp/.X11-unix                \
+               eurobots/carnd_capstone /bin/bash -c                  \
+               "source /opt/ros/kinetic/setup.bash;
+                source ros/devel/setup.bash;
+                roslaunch ros/launch/styx.launch"
+fi


### PR DESCRIPTION
Example:

./run.sh data/just_traffic_light.bag

Note: it currently crashes because some data might be missing in the bag file. To be investigated in further commits.

This file should probably be refactored since it's becoming
quite big. Hopefully the functionality can be reused for OSX
as well.