### PR TITLE
Adress zero index tl issue

### DIFF
--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -29,15 +29,13 @@ class TLDetector(object):
         sub1 = rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
         sub2 = rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
 
-        '''
-        /vehicle/traffic_lights helps you acquire an accurate ground truth
-        data source for the traffic light classifier, providing the location
-        and current color state of all traffic lights in the simulator.
-        This state can be used to generate classified images or subbed into
-        your solution to help you work on another single component of the node.
-        This topic won't be available when testing your solution in real life
-        so don't rely on it in the final submission.
-        '''
+        # /vehicle/traffic_lights provides you with the location of the traffic
+        # light in 3D map space and helps you acquire an accurate ground truth
+        # data source for the traffic light classifier by sending the current
+        # color state of all traffic lights in the simulator.
+        # When testing on the vehicle, the color state will not be available.
+        # You'll need to rely on the position of the light and the camera image
+        # to predict it.
         sub3 = rospy.Subscriber('/vehicle/traffic_lights', TrafficLightArray,
                                 self.traffic_cb)
         sub6 = rospy.Subscriber('/image_color', Image, self.image_cb)

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -24,18 +24,20 @@ class TLDetector(object):
         self.waypoints = None
         self.camera_image = None
         self.lights = []
-        self.tl_waypoints = []
+        self.tl_waypoints_idx = []
 
         sub1 = rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
         sub2 = rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
 
-        # /vehicle/traffic_lights provides you with the location of the traffic
-        # light in 3D map space and helps you acquire an accurate ground truth
-        # data source for the traffic light classifier by sending the current
-        # color state of all traffic lights in the simulator.
-        # When testing on the vehicle, the color state will not be available.
-        # You'll need to rely on the position of the light and the camera image
-        # to predict it.
+        '''
+        /vehicle/traffic_lights helps you acquire an accurate ground truth
+        data source for the traffic light classifier, providing the location
+        and current color state of all traffic lights in the simulator.
+        This state can be used to generate classified images or subbed into
+        your solution to help you work on another single component of the node.
+        This topic won't be available when testing your solution in real life
+        so don't rely on it in the final submission.
+        '''
         sub3 = rospy.Subscriber('/vehicle/traffic_lights', TrafficLightArray,
                                 self.traffic_cb)
         sub6 = rospy.Subscriber('/image_color', Image, self.image_cb)
@@ -79,7 +81,7 @@ class TLDetector(object):
         """
         self.has_image = True
         self.camera_image = msg
-        light_wp, state = self.process_traffic_lights()
+        light_wp_idx, state = self.process_traffic_lights()
 
         # Publish upcoming red lights at camera frequency.
         # Each predicted state has to occur `STATE_COUNT_THRESHOLD` number
@@ -90,9 +92,9 @@ class TLDetector(object):
             self.state = state
         elif self.state_count >= STATE_COUNT_THRESHOLD:
             self.last_state = self.state
-            light_wp = light_wp if state == TrafficLight.RED else -1
-            self.last_wp = light_wp
-            self.upcoming_red_light_pub.publish(Int32(light_wp))
+            light_wp_idx = light_wp_idx if state == TrafficLight.RED else -1
+            self.last_wp = light_wp_idx
+            self.upcoming_red_light_pub.publish(Int32(light_wp_idx))
         else:
             self.upcoming_red_light_pub.publish(Int32(self.last_wp))
         self.state_count += 1
@@ -269,17 +271,62 @@ class TLDetector(object):
         # Get classification
         return self.light_classifier.get_classification(img_traffic_light)
 
-    def get_tl_waypoints(self):
+    def get_tl_waypoints_idx(self):
         """ Converts array self.lights with trafic
         light positions to get_closest_waypoint_idx array with PoseStamped
         traffic light waypoints
-
         """
 
         for light in self.lights:
-            self.tl_waypoints.append(
+            self.tl_waypoints_idx.append(
                 self.get_closest_waypoint_idx(light.pose.pose)
             )
+
+    def get_closest_tl_wp_idx(self, car_pos_wp_idx, searching_dist_tl):
+        """ Finds closest traffic light waypoint in searching range
+
+        Args:
+            car_pos_wp_idx (Integer): current position of the car
+            searching_dist_tl: number of waypoints that will be searched
+            for a traffic light
+
+        Returns:
+            light_wp_idx: waypoint index of closest traffic light in range
+
+        """
+
+        light_wp_idx = -1
+        # In case that array with traffic light waypoints does not exist,
+        # create it
+        if(self.tl_waypoints_idx == []):
+            self.get_tl_waypoints_idx()
+        # Check distance between car and traffic light to address end of array
+        # issue
+        last_waypoint_index = len(self.waypoints.waypoints) - 1
+        car_distance_from_last_wp = last_waypoint_index - car_pos_wp_idx
+        # Loop thorugh waypoints to find the closest traffic ligt waypoint
+        smallest_tl_distance = 10000
+        for tl_waypoint_idx in self.tl_waypoints_idx:
+            # Cover corner case where traffic light is just behind the
+            # waypoint 0 And the car is near last waypoint so waypoint
+            # index will reset to 0
+            if(searching_dist_tl > (car_distance_from_last_wp) and
+                    tl_waypoint_idx < searching_dist_tl):
+                distance_between_wp = car_distance_from_last_wp
+                + tl_waypoint_idx
+                car_postion_wp_idx_temp = -1 * car_distance_from_last_wp
+            # In any other case take distance between indexes of traffic
+            # light and car position waypoints
+            else:
+                distance_between_wp = abs(car_pos_wp_idx - tl_waypoint_idx)
+                car_postion_wp_idx_temp = car_pos_wp_idx
+            if(distance_between_wp < searching_dist_tl and
+                distance_between_wp < smallest_tl_distance and
+                    car_postion_wp_idx_temp < tl_waypoint_idx):
+                light_wp_idx = tl_waypoint_idx
+                smallest_tl_distance = distance_between_wp
+        # Return index of closest traffic light waypoint in range
+        return light_wp_idx
 
     def process_traffic_lights(self):
         """Finds closest visible traffic light, if one exists,
@@ -293,33 +340,25 @@ class TLDetector(object):
 
         """
 
-        # searching_distance_tl parameter sets distance in which
+        # searching_dist_tl parameter sets distance in which
         # traffic lights will be searched as number of waypoints
-        searching_distance_tl = 120
-
+        searching_dist_tl = 200
+        light_wp_idx = -1
         light = None
-        light_wp = -1
         if(self.pose and self.waypoints):
-            # In case that array with traffic light waypoints does not exist,
-            # create it
-            if(self.tl_waypoints == []):
-                self.get_tl_waypoints()
-            car_position_wp = self.get_closest_waypoint_idx(self.pose.pose)
-            # Loop thorugh waypoints to find the closest traffic ligt waypoint
-            smallest_tl_distance = 10000
-            for tl_waypoint in self.tl_waypoints:
-                distance_between_waypoints = abs(car_position_wp-tl_waypoint)
-                if(distance_between_waypoints < searching_distance_tl and
-                    distance_between_waypoints < smallest_tl_distance and
-                        car_position_wp < tl_waypoint):
-                    light_wp = tl_waypoint
-                    smallest_tl_distance = distance_between_waypoints
+            car_pos_wp_idx = self.get_closest_waypoint_idx(self.pose.pose)
+            light_wp_idx = self.get_closest_tl_wp_idx(
+                car_pos_wp_idx, searching_dist_tl
+                )
 
         # If waypoint has been found get traffic light state
-        if light_wp > -1:
-            light = self.waypoints.waypoints[light_wp]
+        if light_wp_idx > -1:
+            light = self.waypoints.waypoints[light_wp_idx]
             state = self.get_light_state(light)
-            return light_wp, state
+            print(light_wp_idx)
+            return light_wp_idx, state
+        else:
+            print("nowp")
 
         return -1, TrafficLight.UNKNOWN
 

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -320,15 +320,14 @@ class TLDetector(object):
         # create it
         if(self.tl_waypoints_idx == []):
             self.get_tl_waypoints_idx()
-        last_waypoint_idx = len(self.waypoints.waypoints) - 1
-        car_distance_from_last_wp = last_waypoint_idx - car_pos_wp_idx
+        get_distance_in_track = len(self.waypoints.waypoints)
         # Loop thorugh waypoints to find the closest traffic light waypoint
         smallest_tl_distance = 10000
         for tl_waypoint_idx in self.tl_waypoints_idx:
             # Covered corner case where traffic light is just behind the
             # waypoint 0 and the car is near the last waypoint
             distance_between_wp = self.get_distance_in_track(
-                    car_pos_wp_idx, tl_waypoint_idx, last_waypoint_idx
+                    car_pos_wp_idx, tl_waypoint_idx, get_distance_in_track
                 )
             if(distance_between_wp < searching_dist_tl and
                 distance_between_wp < smallest_tl_distance and


### PR DESCRIPTION
When the car reaches end of the track in the simulator waypoint index resets to 0. That would cause problems for traffic light detection before this fix because traffic lights are detected based on difference between waypoint index of car and waypoint index of traffic light.

I have addressed this issue and exported closest traffic light detection code to another get_closest_tl_wp_idx function to make the code more readable.