### PR TITLE
Fix the bugs caused by too slow waypoint updater

### DIFF
--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -27,7 +27,7 @@ verify your TL classifier.
 TODO (for Yousuf and Aaron): Stopline location for each traffic light.
 '''
 
-LOOKAHEAD_WPS = 200  # Number of waypoints we publish
+LOOKAHEAD_WPS = 50  # Number of waypoints we publish
 
 
 class WaypointUpdater(object):
@@ -44,18 +44,20 @@ class WaypointUpdater(object):
         # TODO: Add other member variables you need below
         self.waypoints = None
         self.ego = None
+        self.next_idx = -1
 
         rospy.spin()
 
     def publish(self):
-        idx = self.find_next_waypoint()
-        if idx > -1 and not rospy.is_shutdown():
+        self.next_idx = self.find_next_waypoint()
+        if self.next_idx > -1 and not rospy.is_shutdown():
             rospy.loginfo("Current position ({}, {}), next waypoint: {}"
                           .format(self.ego.pose.position.x,
                                   self.ego.pose.position.y,
-                                  idx))
+                                  self.next_idx))
             waypoints = self.waypoints + self.waypoints
-            waypoints = waypoints[idx:idx+LOOKAHEAD_WPS]
+            waypoints = waypoints[self.next_idx:self.next_idx+LOOKAHEAD_WPS]
+
             lane = Lane()
             lane.header.frame_id = '/world'
             lane.header.stamp = rospy.Time.now()
@@ -94,12 +96,15 @@ class WaypointUpdater(object):
             ego_pose = self.ego.pose
             n_waypoints = len(self.waypoints)
             # Find the closest waypoint
-            for i in range(n_waypoints):
-                wp_pos = self.waypoints[i].pose.pose.position
+            for i in range(self.next_idx, self.next_idx + n_waypoints):
+                idx = (i + n_waypoints) % n_waypoints
+                wp_pos = self.waypoints[idx].pose.pose.position
                 dl = self.euclidean(ego_pose.position, wp_pos)
                 if dl < min_dist:
                     min_dist = dl
-                    min_idx = i
+                    min_idx = idx
+                if min_dist < 10 and dl > min_dist:
+                    break
 
             # Check if we are behind or past the closest waypoint
             wp_pos = self.waypoints[min_idx].pose.pose.position


### PR DESCRIPTION
The waypoint updater is too slow and causes delays in processing `/current_pose`. This fix implements a speedup for calculating the `/final_waypoints`, but when implementing the full waypoint updater the code should be changed to do the updates at regular intervals. `/current_pose` seems to be sent too often.