### PR TITLE
Unsubscribe from /base_waypoints once we got the data

### DIFF
--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -35,7 +35,8 @@ class WaypointUpdater(object):
         rospy.init_node('waypoint_updater')
 
         rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
-        rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
+        self.base_waypoints_sub = \
+            rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
         rospy.Subscriber('/traffic_waypoint', Int32, self.traffic_cb)
         rospy.Subscriber('/obstacle_waypoint', Lane, self.obstacle_cb)
 
@@ -73,6 +74,9 @@ class WaypointUpdater(object):
     def waypoints_cb(self, lane):
         if self.waypoints is None:
             self.waypoints = lane.waypoints
+
+            # Unsubscribe so that waypoint loader stops publishing
+            self.base_waypoints_sub.unregister()
 
     def traffic_cb(self, msg):
         # TODO: Callback for /traffic_waypoint message. Implement


### PR DESCRIPTION
This way, `waypoint_loader` will stop publishing
(since nobody subscribes to it), improving
CPU performance.

Reference: https://carnd.slack.com/archives/C6NVDVAQ3/p1505614724000035