### PR TITLE
Print TL detector data to log, not screen

### DIFF
--- a/ros/src/tl_detector/launch/tl_detector.launch
+++ b/ros/src/tl_detector/launch/tl_detector.launch
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-    <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node"/>
+    <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" cwd="node"/>
 </launch>

--- a/ros/src/tl_detector/launch/tl_detector_site.launch
+++ b/ros/src/tl_detector/launch/tl_detector_site.launch
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <launch>
-    <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node"/>
-    <node pkg="tl_detector" type="light_publisher.py" name="light_publisher" output="screen" cwd="node"/>
+    <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" cwd="node"/>
+    <node pkg="tl_detector" type="light_publisher.py" name="light_publisher" cwd="node"/>
 </launch>


### PR DESCRIPTION
For consistency with other modules, and to keep the terminal
clean.