### PR TITLE
Move subscribers to the end of the constructors

### DIFF
--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -53,13 +53,6 @@ class DBWNode(object):
         max_lat_accel = rospy.get_param('~max_lat_accel', 3.)
         max_steer_angle = rospy.get_param('~max_steer_angle', 8.)
 
-        self.steer_pub = rospy.Publisher('/vehicle/steering_cmd',
-                                         SteeringCmd, queue_size=1)
-        self.throttle_pub = rospy.Publisher('/vehicle/throttle_cmd',
-                                            ThrottleCmd, queue_size=1)
-        self.brake_pub = rospy.Publisher('/vehicle/brake_cmd',
-                                         BrakeCmd, queue_size=1)
-
         # Create controller
         self.controller = Controller(vehicle_mass, decel_limit, accel_limit,
                                      wheel_radius, wheel_base,
@@ -72,7 +65,15 @@ class DBWNode(object):
         self.last_dbw_enabled = False
         self.last_time = None
 
-        # Subscribe to all the necessary topics
+        # ROS publishers
+        self.steer_pub = rospy.Publisher('/vehicle/steering_cmd',
+                                         SteeringCmd, queue_size=1)
+        self.throttle_pub = rospy.Publisher('/vehicle/throttle_cmd',
+                                            ThrottleCmd, queue_size=1)
+        self.brake_pub = rospy.Publisher('/vehicle/brake_cmd',
+                                         BrakeCmd, queue_size=1)
+
+        # ROS subscribers
         rospy.Subscriber('/current_velocity', TwistStamped,
                          self.velocity_cb, queue_size=1)
         rospy.Subscriber('/twist_cmd', TwistStamped,

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -35,6 +35,17 @@ class WaypointUpdater(object):
     def __init__(self):
         rospy.init_node('waypoint_updater')
 
+        self.waypoints = None
+        self.ego = None
+        self.next_idx = -1
+
+        # ROS publishers
+        self.pub = rospy.Publisher('/final_waypoints', Lane, queue_size=1)
+        self.pub_path = rospy.Publisher('/local_path', Path, queue_size=1)
+        self.pub_next = rospy.Publisher('/next_waypoint',
+                                        PoseStamped, queue_size=1)
+
+        # ROS subscribers
         rospy.Subscriber('/current_pose', PoseStamped,
                          self.pose_cb, queue_size=1)
         self.base_waypoints_sub = \
@@ -44,16 +55,6 @@ class WaypointUpdater(object):
                          self.traffic_cb, queue_size=1)
         rospy.Subscriber('/obstacle_waypoint', Lane,
                          self.obstacle_cb, queue_size=1)
-
-        self.pub = rospy.Publisher('/final_waypoints', Lane, queue_size=1)
-        self.pub_path = rospy.Publisher('/local_path', Path, queue_size=1)
-        self.pub_next = rospy.Publisher('/next_waypoint',
-                                        PoseStamped, queue_size=1)
-
-        # TODO: Add other member variables you need below
-        self.waypoints = None
-        self.ego = None
-        self.next_idx = -1
 
         rospy.spin()
 


### PR DESCRIPTION
To avoid race conditions (a new thread is started after creating
the subscriber, which could try to access internal data that
is not yet available).

Fixes #39.