### PR TITLE
Use brake_deadband when calculating brake torque

### DIFF
--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -64,7 +64,7 @@ class DBWNode(object):
         self.controller = Controller(vehicle_mass, decel_limit, accel_limit,
                                      wheel_radius, wheel_base,
                                      steer_ratio, max_lat_accel,
-                                     max_steer_angle)
+                                     max_steer_angle, brake_deadband)
         self.velocity = None
         self.twist = None
         self.dbw_enabled = False

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -64,7 +64,8 @@ class DBWNode(object):
         self.controller = Controller(vehicle_mass, decel_limit, accel_limit,
                                      wheel_radius, wheel_base,
                                      steer_ratio, max_lat_accel,
-                                     max_steer_angle, brake_deadband)
+                                     max_steer_angle, brake_deadband,
+                                     fuel_capacity)
         self.velocity = None
         self.twist = None
         self.dbw_enabled = False

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -1,4 +1,3 @@
-import rospy
 from pid import PID
 from yaw_controller import YawController
 GAS_DENSITY = 2.858
@@ -7,12 +6,14 @@ ONE_MPH = 0.44704
 
 class Controller(object):
     def __init__(self, vehicle_mass, decel_limit, accel_limit, wheel_radius,
-                 wheel_base, steer_ratio, max_lat_accel, max_steer_angle):
+                 wheel_base, steer_ratio, max_lat_accel, max_steer_angle,
+                 brake_deadband):
         self.velocity_pid = PID(0.2, 0.0, 3, mn=decel_limit, mx=accel_limit)
-        self.yawController = YawController(wheel_base, steer_ratio, 5,
-                                           max_lat_accel, max_steer_angle)
+        self.yaw_controller = YawController(wheel_base, steer_ratio, 5,
+                                            max_lat_accel, max_steer_angle)
         self.vehicle_mass = vehicle_mass
         self.wheel_radius = wheel_radius
+        self.brake_deadband = brake_deadband
 
     def reset(self):
         self.velocity_pid.reset()
@@ -20,19 +21,22 @@ class Controller(object):
     def control(self, twist, velocity, time_diff):
         velocity_cte = twist.twist.linear.x - velocity.twist.linear.x
         linear_acceleration = self.velocity_pid.step(velocity_cte, time_diff)
-        steer = self.yawController.get_steering(twist.twist.linear.x,
-                                                twist.twist.angular.z,
-                                                velocity.twist.linear.x)
+        steer = self.yaw_controller.get_steering(twist.twist.linear.x,
+                                                 twist.twist.angular.z,
+                                                 velocity.twist.linear.x)
 
         if linear_acceleration > 0.0:
             throttle = linear_acceleration
-            brake = 0.0
+            brake_torque = 0.0
         else:
             throttle = 0.0
-            brake_acceleration = -linear_acceleration
-            brake = brake_acceleration * self.vehicle_mass * self.wheel_radius
+
+            deceleration = -linear_acceleration
+            brake_deceleration = max(0, deceleration - self.brake_deadband)
+            brake_force = brake_deceleration * self.vehicle_mass
+            brake_torque = brake_force * self.wheel_radius  # [N·m]
 
         # TODO remove this when we focus on braking, keep it simple for now
-        brake = 0.0
+        brake_torque = 0.0
 
-        return throttle, brake, steer
+        return throttle, brake_torque, steer


### PR DESCRIPTION
Basically, if the braking deceleration is smaller
than the brake deadband, it's not required to
apply the brakes, since the vehicle will
decelerate on it's own due to engine, drag, etc.

Fixes #61