### PR TITLE
Set a minimum speed of 1m/s for Yaw Controller

### DIFF
--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -11,7 +11,7 @@ class Controller(object):
                  brake_deadband, fuel_capacity, max_throttle_percent):
         self.velocity_pid = PID(1.5, 0.001, 0.,
                                 mn=decel_limit, mx=max_throttle_percent)
-        self.yaw_controller = YawController(wheel_base, steer_ratio, 5,
+        self.yaw_controller = YawController(wheel_base, steer_ratio, 1,
                                             max_lat_accel, max_steer_angle)
         self.wheel_radius = wheel_radius
         self.brake_deadband = brake_deadband


### PR DESCRIPTION
Average walking speed is 5km/h
I tested it in the simulator at 5km/h max velocity and the car manages to follow the path, though with a lot of slow wiggling (much like one would drive and correct their path once in a while only).

Closes #114 