### PR TITLE
Use TensorFlow 1.0.0 in docker images

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:8.0-cudnn6-runtime-ubuntu16.04
+FROM nvidia/cuda:8.0-cudnn5-runtime-ubuntu16.04
 
 # Install ROS
 RUN apt-get update  && \

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -2,4 +2,4 @@ FROM eurobots/carnd_capstone:latest
 
 # Uninstall TensorFlow (CPU) and install TensorFlow GPU
 RUN pip uninstall --yes tensorflow  && \
-    pip install --upgrade tensorflow-gpu
+    pip install --ignore-installed tensorflow-gpu==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy>=1.13.1
 Pillow>=2.2.1
 scipy
 keras
-tensorflow
+tensorflow==1.0.0
 h5py
 pycodestyle
 pydocstyle


### PR DESCRIPTION
NOTE: currently our code does NOT work with this version of TF.
DO NOT MERGE until we know for sure the code is working.

Fixes #119